### PR TITLE
Bugfix: initialize properly eventlist and index

### DIFF
--- a/src/DataManager.cpp
+++ b/src/DataManager.cpp
@@ -18,6 +18,8 @@
 
 DataManager::DataManager()
     : currentEvent_(0),
+      currentIndex_(0),
+      eventList_{currentEvent_},
       rootFile_(nullptr),
       trackList_(nullptr) {}
 
@@ -48,6 +50,7 @@ bool DataManager::LoadFile(const std::string& filename) {
 
     // prepare event list
     TTreeReaderValue<int> evtID_(trajReader_,"evtID");
+    eventList_.clear();
     while (trajReader_.Next()) {
         if (std::find(eventList_.begin(),eventList_.end(), *evtID_) == eventList_.end())
             eventList_.push_back(*evtID_);
@@ -223,7 +226,7 @@ void DataManager::SetTrackStylebyPDG(TEveLine* track, int pdg){
 std::string DataManager::GetSummary() const {
     std::stringstream ss;
     ss << "Event #" << currentEvent_;
-    ss << " (" << currentIndex_ << " of " << eventList_.size()-1 << ") loaded";
+    ss << " (" << currentIndex_+1 << " of " << eventList_.size() << ") loaded";
     ss << "\n\nTrack count: " << (trackList_ ? trackList_->NumChildren() : 0);
     ss << "\nKinetic energy threshold: " << kinECut_ << " MeV";
     ss << "\nLength threshold: " << lengthCut_ << " cm";


### PR DESCRIPTION
In case of geometry-only visualization, the `currentIndex_` and `eventList_` were left undefined resulting in large random numbers being reported in the summary information of the "Event control" tab. This PR fixes their initialization.

I'm also updating how event indexes are being displayed: the first in a file of 15 events is now reported as `(1 of 15)` instead of `(0 of 14)` as it is more natural for humans.
